### PR TITLE
Fix mobile file upload: remove webkitdirectory on mobile, add upload to drawer

### DIFF
--- a/src/components/ui/app-shell.tsx
+++ b/src/components/ui/app-shell.tsx
@@ -82,6 +82,7 @@ export function AppShell({
               statsPanel={statsPanel}
               filterPanel={filterPanel}
               activityList={activityList}
+              uploadZone={uploadZone}
               hasActivities={hasActivities}
             />
           )}

--- a/src/components/ui/mobile-drawer.tsx
+++ b/src/components/ui/mobile-drawer.tsx
@@ -3,12 +3,13 @@
 import { ReactNode, useCallback, useRef, useState } from 'react'
 import { cn } from '@/lib/utils'
 
-type Section = 'stats' | 'filters' | 'activities'
+type Section = 'stats' | 'filters' | 'activities' | 'upload'
 
 interface MobileDrawerProps {
   statsPanel?: ReactNode
   filterPanel?: ReactNode
   activityList?: ReactNode
+  uploadZone?: ReactNode
   hasActivities?: boolean
   className?: string
 }
@@ -50,6 +51,7 @@ export function MobileDrawer({
   statsPanel,
   filterPanel,
   activityList,
+  uploadZone,
   hasActivities = false,
   className,
 }: MobileDrawerProps) {
@@ -169,6 +171,14 @@ export function MobileDrawer({
           onToggle={() => toggleSection('stats')}
         >
           {statsPanel}
+        </CollapsibleSection>
+
+        <CollapsibleSection
+          title="upload"
+          isOpen={openSection === 'upload'}
+          onToggle={() => toggleSection('upload')}
+        >
+          {uploadZone}
         </CollapsibleSection>
       </div>
     </div>

--- a/src/components/ui/upload-zone.tsx
+++ b/src/components/ui/upload-zone.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useState, useEffect } from 'react'
 import { cn } from '@/lib/utils'
+import { useIsMobile } from '@/hooks/use-media-query'
 
 interface UploadZoneProps {
   onFilesSelected: (files: File[]) => void
@@ -24,14 +25,15 @@ export function UploadZone({
   error,
   onErrorDismiss,
 }: UploadZoneProps) {
+  const isMobile = useIsMobile()
   const [isDragging, setIsDragging] = useState(false)
   const [expanded, setExpanded] = useState(defaultExpanded)
   const inputRef = useCallback((el: HTMLInputElement | null) => {
-    if (el) {
+    if (el && !isMobile) {
       el.setAttribute('webkitdirectory', '')
       el.setAttribute('directory', '')
     }
-  }, [])
+  }, [isMobile])
 
   useEffect(() => {
     if (!defaultExpanded) {
@@ -203,6 +205,7 @@ export function UploadZone({
             multiple
             onChange={handleFileInput}
             disabled={isLoading}
+            {...(isMobile ? { accept: '.gpx,.fit,.fit.gz' } : {})}
           />
 
           {error ? (
@@ -237,10 +240,12 @@ export function UploadZone({
           ) : (
             <div className="text-center py-4 md:py-2 min-h-[100px] md:min-h-0 flex flex-col justify-center">
               <div className="text-sm-compact mb-1">
-                {hasActivities ? '[_] drop more files' : '[_] drop files here'}
+                {isMobile
+                  ? (hasActivities ? '[_] tap to add more files' : '[_] tap to select files')
+                  : (hasActivities ? '[_] drop more files' : '[_] drop files here')}
               </div>
               <div className="text-xs-compact text-panel-muted">
-                strava export folder or .gpx/.fit files
+                {isMobile ? '.gpx/.fit activity files' : 'strava export folder or .gpx/.fit files'}
               </div>
             </div>
           )}


### PR DESCRIPTION
The file input unconditionally set webkitdirectory/directory attributes,
which are not supported on iOS Safari and unreliable on Android, breaking
the file picker on mobile devices entirely. Now these attributes are only
set on desktop, while mobile gets an accept filter for .gpx/.fit/.fit.gz
and tap-friendly label text.

Also passes the upload zone into MobileDrawer so mobile users can add
more files after their initial upload (previously the upload zone
disappeared once activities were loaded).

https://claude.ai/code/session_01TPea4zNPGnEFDrhszTbJav